### PR TITLE
Feature/preserve crossout in storage

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
   $("#addTaskBtn").click(function() {
     var taskInput = $("#taskInput").val().trim();
     if (taskInput !== "") {
-      addTaskToList(taskInput, null);
+      addTaskToList(taskInput, undefined);
       saveTasksToLocalStorage();
       $("#taskInput").val(""); // Clear the input field
     }
@@ -64,7 +64,7 @@ $(document).ready(function() {
       if ($(this).css('textDecoration').includes("line-through")) {
         crossedOutTasks.push(text.slice(0, text.length - 2));
       } else {
-        crossedOutTasks.push(null);
+        crossedOutTasks.push(undefined);
       }
     });
     

--- a/handlers.js
+++ b/handlers.js
@@ -1,15 +1,17 @@
 $(document).ready(function() {
   // Load tasks from local storage
   var tasks = JSON.parse(localStorage.getItem('tasks')) || [];
-  tasks.forEach(function(task) {
-    addTaskToList(task);
+  var crossedOutTasks = JSON.parse(localStorage.getItem('crossedOut')) || [];
+
+  tasks.forEach(function(task, index) {
+    addTaskToList(task, crossedOutTasks[index]);
   });
   
   // Add task button click event
   $("#addTaskBtn").click(function() {
     var taskInput = $("#taskInput").val().trim();
     if (taskInput !== "") {
-      addTaskToList(taskInput);
+      addTaskToList(taskInput, null);
       saveTasksToLocalStorage();
       $("#taskInput").val(""); // Clear the input field
     }
@@ -24,20 +26,27 @@ $(document).ready(function() {
   // Handler for approving a task
   $(document).on("click", ".approve-task", function() {
     var listItem = $(this).parent();
-    if (listItem.css('textDecoration').includes("line-through")) {
+    var isCrossedOut = listItem.css('textDecoration').includes("line-through");
+    
+    if (isCrossedOut) {
       listItem.css('textDecoration', 'none');
     } else {
       listItem.css('textDecoration', 'line-through');
     }
+    
     saveTasksToLocalStorage();
   });
 
   // Function to add a task to the list
-  function addTaskToList(task) {
+  function addTaskToList(task, crossedOutTask) {
     var listItem = $("<li>").addClass("list-group-item").text(task);
     var deleteButton = $("<button>").addClass("btn-cancel float-right delete-task").html("&times;");
     var approveButton = $("<button>").addClass("btn-approve float-right mr-2 approve-task").html("&#10003;");
 
+    if (crossedOutTask) {
+      listItem.css('textDecoration', 'line-through');
+    }
+    
     listItem.append(deleteButton);
     listItem.append(approveButton);
     $("#taskList").append(listItem);
@@ -46,10 +55,20 @@ $(document).ready(function() {
   // Function to save tasks to local storage
   function saveTasksToLocalStorage() {
     var tasks = [];
+    var crossedOutTasks = [];
+    
     $("#taskList li").each(function() {
       var text = $(this).text();
-      tasks.push(text.slice(0,text.length-2));
+      tasks.push(text.slice(0, text.length - 2));
+      
+      if ($(this).css('textDecoration').includes("line-through")) {
+        crossedOutTasks.push(text.slice(0, text.length - 2));
+      } else {
+        crossedOutTasks.push(null);
+      }
     });
+    
     localStorage.setItem('tasks', JSON.stringify(tasks));
+    localStorage.setItem('crossedOut', JSON.stringify(crossedOutTasks));
   }
 });


### PR DESCRIPTION
**PR Description**

**🎉✨ Feature: Preserve Crossed-Out State of Tasks using Local Storage ✨🎉**

This PR introduces an exciting enhancement to our task management functionality! Now, when you cross out a task, its state will be preserved even if you refresh the page or close the tab. 📝✅

Here's a summary of the changes:

**🔄 Modified Handlers:** The handlers have been updated to include the preservation of the crossed-out state for tasks.

**📦 Local Storage:** The tasks and their corresponding crossed-out states are stored in the local storage of the browser. This allows us to retrieve and persist the crossed-out state across sessions.

**📝 Add Task:** When adding a new task, the crossed-out state is initially set to null. If a task is added with a pre-existing crossed-out state, it will be preserved.

**✂️ Delete Task:** Deleting a task correctly updates the local storage, ensuring that the crossed-out state is accurately maintained.

**✅ Approve Task:** The handler for approving a task has been modified to toggle the crossed-out state, preserving it in the local storage.